### PR TITLE
mnt: drop unused cython

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,7 +28,7 @@ jobs:
           pip3 install -r requirements.txt
           pip3 install wheel
           pip3 install setuptools
-          pip3 install --upgrade cython numpy pyshp six
+          pip3 install --upgrade numpy pyshp six
           pip3 install ipython
           pip3 install requests
           pip3 install urllib3

--- a/continuous_integration/environment_actions.yml
+++ b/continuous_integration/environment_actions.yml
@@ -9,7 +9,6 @@ dependencies:
   - scipy
   - xarray
   - matplotlib
-  - cython
   - netcdf4
   - pint
   - flake8

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,9 +25,6 @@ __ http://www.scipy.org
 * Xarray__
 __ https://xarray.dev
 
-* Cython__
-__ https://cython.readthedocs.io/en/latest/
-
 * matplotlib__
 __ http://matplotlib.org/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ numpy
 scipy
 xarray
 matplotlib
-cython
 netcdf4
 pint


### PR DESCRIPTION
I could be making a total fool of myself, but I don't believe this repo requires cython.

FYI, I'm attempting to create a package for this on conda-forge conda-forge/staged-recipes#24910